### PR TITLE
Add hosting config and relative API path

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,23 @@
   "functions": {
     "source": "functions-v2",
     "runtime": "nodejs22"
+  },
+  "hosting": {
+    "public": "frontend/dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "/api/**",
+        "function": "api"
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
   }
 }

--- a/frontend/src/pages/AddPage.jsx
+++ b/frontend/src/pages/AddPage.jsx
@@ -19,9 +19,8 @@ export default function AddPage() {
       return;
     }
 
-    const res = await fetch(
-      "https://asia-northeast1-lifelog-app-6b84f.cloudfunctions.net/api/addPage",
-      {
+    const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+    const res = await fetch(`${API_BASE}/api/pages`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/frontend/src/pages/ListPage.jsx
+++ b/frontend/src/pages/ListPage.jsx
@@ -10,9 +10,8 @@ export default function ListPage({ uid }) {
   useEffect(() => {
     async function fetchPages() {
       try {
-        const res = await fetch(
-          `https://asia-northeast1-lifelog-app-6b84f.cloudfunctions.net/api/listPages?uid=${uid}`
-        );
+        const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
+        const res = await fetch(`${API_BASE}/api/pages?uid=${uid}`);
         const data = await res.json();
         setPages(data.pages || []);
         setMessage(`${data.pages.length} 件取得`);

--- a/functions-v2/index.js
+++ b/functions-v2/index.js
@@ -1,38 +1,60 @@
-// functions-v2/index.js
-const functions = require("firebase-functions/v2");
+const functions = require("firebase-functions/v2/https");
 const admin = require("firebase-admin");
-const cors = require("cors")({ origin: true });
+const express = require("express");
+const cors = require("cors");
 
 admin.initializeApp();
 const db = admin.firestore();
 
-exports.listPages = functions.https.onRequest(
-  {
-    region: "asia-northeast1" // ← ここを明示
-  },
-  async (req, res) => {
-    cors(req, res, async () => {
-      const uid = req.query.uid;
-      if (!uid) {
-        return res.status(400).json({ error: "uid is required" });
-      }
+const app = express();
+app.use(cors({ origin: true }));
+app.use(express.json());
 
-      try {
-        const snapshot = await db
-          .collection("pages")
-          .where("uid", "==", uid)
-          .get();
+const router = express.Router();
 
-        const pages = snapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...doc.data(),
-        }));
-
-        return res.json({ pages });
-      } catch (error) {
-        console.error("Error fetching pages:", error);
-        return res.status(500).json({ error: "Internal Server Error" });
-      }
-    });
+// GET /api/pages?uid=xxx
+router.get("/pages", async (req, res) => {
+  const uid = req.query.uid;
+  if (!uid) {
+    return res.status(400).json({ error: "uid is required" });
   }
-);
+
+  try {
+    const snapshot = await db
+      .collection("pages")
+      .where("uid", "==", uid)
+      .get();
+    const pages = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json({ pages });
+  } catch (error) {
+    console.error("Error fetching pages:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+// POST /api/pages
+router.post("/pages", async (req, res) => {
+  const { uid, title, category = "", meta = {}, tags = [] } = req.body || {};
+  if (!uid || !title) {
+    return res.status(400).json({ error: "uid and title are required" });
+  }
+
+  try {
+    const docRef = await db.collection("pages").add({
+      uid,
+      title,
+      category,
+      meta,
+      tags,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.json({ id: docRef.id });
+  } catch (error) {
+    console.error("Error adding page:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
+app.use("/api", router);
+
+exports.api = functions.onRequest({ region: "asia-northeast1" }, app);

--- a/functions-v2/package.json
+++ b/functions-v2/package.json
@@ -11,6 +11,8 @@
   "description": "",
   "dependencies": {
     "firebase-admin": "^13.4.0",
-    "firebase-functions": "^6.3.2"
+    "firebase-functions": "^6.3.2",
+    "express": "^4.21.0",
+    "cors": "^2.8.5"
   }
 }


### PR DESCRIPTION
## Summary
- configure Firebase Hosting to serve the frontend and rewrite `/api` requests
- use an environment variable for API base URL in AddPage and ListPage

## Testing
- `node -e "require('./functions-v2/index.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68654fbe1f54832789fb726ad3aa7b7f